### PR TITLE
Ac regex

### DIFF
--- a/conda_deps/conda_deps.py
+++ b/conda_deps/conda_deps.py
@@ -244,7 +244,7 @@ def scan_r_imports(filename):
     with open(filename) as f:
         data = f.read()
 
-    results = re.findall(r"library\((\W*)([\w,.]+)(\W*)\)", data)
+    results = re.findall(r"library\((\W*)([\w\.]+)(\W*)\)", data)
 
     for r in results:
         # the result of re.findall is a list of tuples where

--- a/conda_deps/conda_deps.py
+++ b/conda_deps/conda_deps.py
@@ -244,7 +244,8 @@ def scan_r_imports(filename):
     with open(filename) as f:
         data = f.read()
 
-    results = re.findall(r"library\((\W*)(\w*)(\W*)\)", data)
+    results = re.findall(r"library\((\W*)([\w,.]+)(\W*)\)", data)
+
     for r in results:
         # the result of re.findall is a list of tuples where
         # (match.group(0), match.group(1), match.group(2))

--- a/conda_deps/r_deps.json
+++ b/conda_deps/r_deps.json
@@ -1,4 +1,6 @@
 {
+"BSgenome.Hsapiens.UCSC.hg19":"bioconductor-bsgenome.hsapiens.ucsc.hg19",
+"ATACseqQC":"bioconductor-atacseqqc",
 "BiSeq":"bioconductor-biseq",
 "Biobase":"bioconductor-biobase",
 "ChIPQC":"bioconductor-chipqc",


### PR DESCRIPTION
@sebastian-luna-valero 

I have modified the regex for the r deps because, for certain packages that contain `.` characters, the script will not pick up the package.

For example, 
`library(BSgenome.Hsapiens.UCSC.hg19)` 